### PR TITLE
fix(api): share safeEqual and fix admin typecheck failure

### DIFF
--- a/apps/moneyglass-admin/src/middleware.ts
+++ b/apps/moneyglass-admin/src/middleware.ts
@@ -1,30 +1,6 @@
+import { safeEqual } from "@ojpp/api";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
-/**
- * 定数時間の文字列比較（タイミング攻撃対策）
- */
-function safeEqual(a: string, b: string): boolean {
-  const encoder = new TextEncoder();
-  const aBuf = encoder.encode(a);
-  const bBuf = encoder.encode(b);
-  if (aBuf.byteLength !== bBuf.byteLength) {
-    // 長さが異なっても定数時間で比較（ダミー比較）
-    const dummy = new Uint8Array(aBuf.byteLength);
-    crypto.subtle.timingSafeEqual?.(aBuf, dummy);
-    return false;
-  }
-  // Edge Runtime では crypto.subtle.timingSafeEqual が利用可能
-  if (typeof crypto.subtle?.timingSafeEqual === "function") {
-    return crypto.subtle.timingSafeEqual(aBuf, bBuf);
-  }
-  // フォールバック: XOR ベースの定数時間比較
-  let result = 0;
-  for (let i = 0; i < aBuf.byteLength; i++) {
-    result |= aBuf[i] ^ bBuf[i];
-  }
-  return result === 0;
-}
 
 /**
  * Admin アプリの Basic 認証ミドルウェア

--- a/apps/parliscope-admin/src/middleware.ts
+++ b/apps/parliscope-admin/src/middleware.ts
@@ -1,27 +1,6 @@
+import { safeEqual } from "@ojpp/api";
 import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
-
-/**
- * 定数時間の文字列比較（タイミング攻撃対策）
- */
-function safeEqual(a: string, b: string): boolean {
-  const encoder = new TextEncoder();
-  const aBuf = encoder.encode(a);
-  const bBuf = encoder.encode(b);
-  if (aBuf.byteLength !== bBuf.byteLength) {
-    const dummy = new Uint8Array(aBuf.byteLength);
-    crypto.subtle.timingSafeEqual?.(aBuf, dummy);
-    return false;
-  }
-  if (typeof crypto.subtle?.timingSafeEqual === "function") {
-    return crypto.subtle.timingSafeEqual(aBuf, bBuf);
-  }
-  let result = 0;
-  for (let i = 0; i < aBuf.byteLength; i++) {
-    result |= aBuf[i] ^ bBuf[i];
-  }
-  return result === 0;
-}
 
 /**
  * Admin アプリの Basic 認証ミドルウェア

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -4,4 +4,5 @@ export { buildPaginatedResponse, parsePagination } from "./pagination";
 export type { RateLimitConfig } from "./rate-limit";
 export { checkRateLimit } from "./rate-limit";
 export { jsonResponse, optionsResponse } from "./response";
+export { safeEqual } from "./security";
 export { serializeBigInt } from "./serialize";

--- a/packages/api/src/security.ts
+++ b/packages/api/src/security.ts
@@ -1,0 +1,27 @@
+type TimingSafeEqual = (a: ArrayBufferView, b: ArrayBufferView) => boolean;
+
+interface ExtendedSubtleCrypto extends SubtleCrypto {
+  timingSafeEqual?: TimingSafeEqual;
+}
+
+/**
+ * Constant-time string comparison when possible.
+ * Falls back to XOR-based comparison in environments without timingSafeEqual.
+ */
+export function safeEqual(a: string, b: string): boolean {
+  const encoder = new TextEncoder();
+  const aBuf = encoder.encode(a);
+  const bBuf = encoder.encode(b);
+  const subtle = crypto.subtle as ExtendedSubtleCrypto;
+
+  if (aBuf.byteLength === bBuf.byteLength && typeof subtle.timingSafeEqual === "function") {
+    return subtle.timingSafeEqual(aBuf, bBuf);
+  }
+
+  let result = aBuf.byteLength ^ bBuf.byteLength;
+  const maxLength = Math.max(aBuf.byteLength, bBuf.byteLength);
+  for (let i = 0; i < maxLength; i++) {
+    result |= (aBuf[i] ?? 0) ^ (bBuf[i] ?? 0);
+  }
+  return result === 0;
+}


### PR DESCRIPTION
## Summary
add shared `safeEqual` utility in `@ojpp/api`
 replace duplicated admin middleware implementations with shared import\n- remove direct typed access to `crypto.subtle.timingSafeEqual` from app code
## Why
`pnpm typecheck` failed with TS2339 because `SubtleCrypto` does not define `timingSafeEqual` in standard typings.

## Verification
 `pnpm --recursive --stream run typecheck` passes
 `pnpm -s test` passes