### PR TITLE
build: pnpm catalog導入による依存バージョン一元管理

### DIFF
--- a/apps/culturescope-web/package.json
+++ b/apps/culturescope-web/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/moneyglass-admin/package.json
+++ b/apps/moneyglass-admin/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@supabase/supabase-js": "^2.49.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "@supabase/supabase-js": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/moneyglass-web/package.json
+++ b/apps/moneyglass-web/package.json
@@ -15,18 +15,18 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@supabase/supabase-js": "^2.49.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "@supabase/supabase-js": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/parliscope-admin/package.json
+++ b/apps/parliscope-admin/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@supabase/supabase-js": "^2.49.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "@supabase/supabase-js": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/parliscope-web/package.json
+++ b/apps/parliscope-web/package.json
@@ -14,18 +14,18 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "@supabase/supabase-js": "^2.49.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "@supabase/supabase-js": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/policydiff-web/package.json
+++ b/apps/policydiff-web/package.json
@@ -15,19 +15,19 @@
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
     "gray-matter": "^4.0.3",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "recharts": "^2.15.4",
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:",
     "remark": "^15.0.0",
     "remark-html": "^16.0.0"
   },
   "devDependencies": {
-    "@tailwindcss/postcss": "^4.0.0",
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "tailwindcss": "^4.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "@tailwindcss/postcss": "catalog:",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "tailwindcss": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/apps/portal-web/package.json
+++ b/apps/portal-web/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/seatmap-web/package.json
+++ b/apps/seatmap-web/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/apps/socialguard-web/package.json
+++ b/apps/socialguard-web/package.json
@@ -14,17 +14,17 @@
     "@ojpp/api": "workspace:*",
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
-    "next": "^15.2.0",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
-    "recharts": "^2.15.0"
+    "next": "catalog:",
+    "react": "catalog:",
+    "react-dom": "catalog:",
+    "recharts": "catalog:"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0",
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "tailwindcss": "catalog:",
+    "@tailwindcss/postcss": "catalog:"
   }
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.0",
-    "typescript": "^5.7.0"
+    "typescript": "catalog:"
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,8 +16,8 @@
     "@ojpp/db": "workspace:*"
   },
   "devDependencies": {
-    "next": "^15.2.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "next": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -18,9 +18,9 @@
     "@prisma/client": "^6.14.0"
   },
   "devDependencies": {
-    "dotenv-cli": "^11.0.0",
+    "dotenv-cli": "catalog:",
     "prisma": "^6.14.0",
-    "tsx": "^4.21.0",
-    "typescript": "^5.7.0"
+    "tsx": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/packages/ingestion/package.json
+++ b/packages/ingestion/package.json
@@ -24,9 +24,9 @@
     "@ojpp/db": "workspace:*"
   },
   "devDependencies": {
-    "dotenv-cli": "^11.0.0",
-    "tsx": "^4.21.0",
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
+    "dotenv-cli": "catalog:",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -11,7 +11,7 @@
     "./theme.css": "./src/theme.css"
   },
   "dependencies": {
-    "react": "^19.0.0",
+    "react": "catalog:",
     "motion": "^11.15.0",
     "lenis": "^1.1.0"
   },
@@ -19,7 +19,7 @@
     "typecheck": "tsc --noEmit --project tsconfig.json"
   },
   "devDependencies": {
-    "@types/react": "^19.0.0",
-    "typescript": "^5.7.0"
+    "@types/react": "catalog:",
+    "typescript": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,48 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+catalogs:
+  default:
+    '@supabase/supabase-js':
+      specifier: ^2.49.0
+      version: 2.95.3
+    '@tailwindcss/postcss':
+      specifier: ^4.0.0
+      version: 4.1.18
+    '@types/react':
+      specifier: ^19.0.0
+      version: 19.2.14
+    '@types/react-dom':
+      specifier: ^19.0.0
+      version: 19.2.3
+    dotenv-cli:
+      specifier: ^11.0.0
+      version: 11.0.0
+    next:
+      specifier: ^15.2.0
+      version: 15.5.12
+    react:
+      specifier: ^19.0.0
+      version: 19.2.4
+    react-dom:
+      specifier: ^19.0.0
+      version: 19.2.4
+    recharts:
+      specifier: ^2.15.0
+      version: 2.15.4
+    tailwindcss:
+      specifier: ^4.0.0
+      version: 4.1.18
+    tsx:
+      specifier: ^4.21.0
+      version: 4.21.0
+    typescript:
+      specifier: ^5.7.0
+      version: 5.9.3
+    vitest:
+      specifier: ^3.0.0
+      version: 3.2.4
+
 importers:
 
   .:
@@ -12,7 +54,7 @@ importers:
         specifier: ^2.3.0
         version: 2.3.15
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
 
   apps/culturescope-web:
@@ -27,35 +69,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/moneyglass-admin:
@@ -70,35 +112,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@supabase/supabase-js':
-        specifier: ^2.49.0
+        specifier: 'catalog:'
         version: 2.95.3
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/moneyglass-web:
@@ -113,38 +155,38 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@supabase/supabase-js':
-        specifier: ^2.49.0
+        specifier: 'catalog:'
         version: 2.95.3
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/parliscope-admin:
@@ -159,35 +201,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@supabase/supabase-js':
-        specifier: ^2.49.0
+        specifier: 'catalog:'
         version: 2.95.3
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/parliscope-web:
@@ -202,38 +244,38 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       '@supabase/supabase-js':
-        specifier: ^2.49.0
+        specifier: 'catalog:'
         version: 2.95.3
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/policydiff-web:
@@ -251,16 +293,16 @@ importers:
         specifier: ^4.0.3
         version: 4.0.3
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.4
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       remark:
         specifier: ^15.0.0
@@ -270,22 +312,22 @@ importers:
         version: 16.0.1
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/portal-web:
@@ -300,35 +342,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/seatmap-web:
@@ -343,35 +385,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   apps/socialguard-web:
@@ -386,35 +428,35 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
       react-dom:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4(react@19.2.4)
       recharts:
-        specifier: ^2.15.0
+        specifier: 'catalog:'
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
     devDependencies:
       '@tailwindcss/postcss':
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
       tailwindcss:
-        specifier: ^4.0.0
+        specifier: 'catalog:'
         version: 4.1.18
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/api:
@@ -424,13 +466,13 @@ importers:
         version: link:../db
     devDependencies:
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/db:
@@ -440,16 +482,16 @@ importers:
         version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       dotenv-cli:
-        specifier: ^11.0.0
+        specifier: 'catalog:'
         version: 11.0.0
       prisma:
         specifier: ^6.14.0
         version: 6.19.2(typescript@5.9.3)
       tsx:
-        specifier: ^4.21.0
+        specifier: 'catalog:'
         version: 4.21.0
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
 
   packages/ingestion:
@@ -459,16 +501,16 @@ importers:
         version: link:../db
     devDependencies:
       dotenv-cli:
-        specifier: ^11.0.0
+        specifier: 'catalog:'
         version: 11.0.0
       tsx:
-        specifier: ^4.21.0
+        specifier: 'catalog:'
         version: 4.21.0
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
       vitest:
-        specifier: ^3.0.0
+        specifier: 'catalog:'
         version: 3.2.4(@types/debug@4.1.12)(@types/node@25.2.3)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/ui:
@@ -480,14 +522,14 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.4
     devDependencies:
       '@types/react':
-        specifier: ^19.0.0
+        specifier: 'catalog:'
         version: 19.2.14
       typescript:
-        specifier: ^5.7.0
+        specifier: 'catalog:'
         version: 5.9.3
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,17 @@ onlyBuiltDependencies:
   - "@prisma/engines"
   - prisma
   - esbuild
+catalog:
+  next: ^15.2.0
+  react: ^19.0.0
+  react-dom: ^19.0.0
+  "@types/react": ^19.0.0
+  "@types/react-dom": ^19.0.0
+  typescript: ^5.7.0
+  vitest: ^3.0.0
+  tailwindcss: ^4.0.0
+  "@tailwindcss/postcss": ^4.0.0
+  recharts: ^2.15.0
+  "@supabase/supabase-js": ^2.49.0
+  dotenv-cli: ^11.0.0
+  tsx: ^4.21.0


### PR DESCRIPTION
## 変更内容

pnpm catalog を導入し、モノレポ内で 2 つ以上のパッケージが共有する依存 13 種のバージョンを `pnpm-workspace.yaml` で一元管理するようにしました。

- `pnpm-workspace.yaml` に `catalog:` セクションを追加（13 エントリ）
- 14 個の `package.json` で catalog 対象の依存バージョンを `"catalog:"` に置換
- `recharts`: policydiff-web `^2.15.4` → `^2.15.0` に統一（caret range で実質同一解決）
- 単一パッケージでしか使われない依存は明示バージョンのまま維持

## 関連 Issue
なし

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] ドキュメント更新
- [x] リファクタリング
- [ ] データ追加・修正
- [ ] CI/CD・インフラ
- [ ] テスト追加・修正

## チェックリスト

- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る
- [x] `pnpm test` が通る
- [x] `pnpm build` が通る
- [x] 非党派性を保っている（特定政党に有利/不利な変更を含まない）
- [x] 個人情報を含まない

## スクリーンショット

UI の変更なし

---

<!-- AIエージェントによる PR の場合: `agent/` ラベルを付与し、行動ログを以下に記載してください -->
