### PR TITLE
fix: biome設定で.nextビルド成果物を除外し build後のlintエラーを解消

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,14 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.3.15/schema.json",
   "files": {
-    "includes": ["apps/**", "packages/**", "*.json", "*.ts", "!packages/db/prisma/generated/**"]
+    "includes": [
+      "apps/**",
+      "packages/**",
+      "*.json",
+      "*.ts",
+      "!packages/db/prisma/generated",
+      "!**/.next"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## 変更内容

biome の `files.includes` に `!**/.next` を追加し、Next.js のビルド成果物ディレクトリ (`.next`) を lint/format の対象から除外しました。

`pnpm build` 後に `pnpm lint` を実行すると、`.next` 内の生成ファイルが biome の検査対象に含まれてしまいエラーになるため、除外パターンを追加しています。

併せて、既存の `includes` 配列を1行1エントリに整形しています。

## 関連 Issue

なし

## 変更の種類

- [x] バグ修正
- [ ] 新機能
- [ ] ドキュメント更新
- [ ] リファクタリング
- [ ] データ追加・修正
- [ ] CI/CD・インフラ
- [ ] テスト追加・修正

## チェックリスト

- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る
- [x] `pnpm test` が通る
- [x] `pnpm build` が通る
- [x] 非党派性を保っている（特定政党に有利/不利な変更を含まない）
- [x] 個人情報を含まない

## スクリーンショット

UI の変更なし
