### PR TITLE
fix(api): serializeBigIntでDateを破壊しないよう修正

### DIFF
--- a/packages/api/src/__tests__/serialize.test.ts
+++ b/packages/api/src/__tests__/serialize.test.ts
@@ -47,4 +47,15 @@ describe("serializeBigInt", () => {
   it("通常の number はそのまま返す", () => {
     expect(serializeBigInt(42)).toBe(42);
   });
+
+  it("Date を壊さず保持する", () => {
+    const date = new Date("2026-01-01T00:00:00.000Z");
+    const result = serializeBigInt({ date, amount: BigInt(1) });
+
+    expect(result).toEqual({
+      date,
+      amount: "1",
+    });
+    expect(result.date).toBeInstanceOf(Date);
+  });
 });

--- a/packages/api/src/serialize.ts
+++ b/packages/api/src/serialize.ts
@@ -4,8 +4,9 @@
 export function serializeBigInt<T>(obj: T): T {
   if (obj === null || obj === undefined) return obj;
   if (typeof obj === "bigint") return String(obj) as unknown as T;
+  if (obj instanceof Date) return obj;
   if (Array.isArray(obj)) return obj.map(serializeBigInt) as unknown as T;
-  if (typeof obj === "object") {
+  if (typeof obj === "object" && isPlainObject(obj)) {
     const result: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
       result[key] = serializeBigInt(value);
@@ -13,4 +14,9 @@ export function serializeBigInt<T>(obj: T): T {
     return result as T;
   }
   return obj;
+}
+
+function isPlainObject(value: object): boolean {
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
 }


### PR DESCRIPTION
## 概要
`serializeBigInt` が `Date` を plain object として再帰処理してしまい、APIレスポンス中の日時が `{}` に壊れる問題を修正します。

## 変更内容
- `serializeBigInt` で `Date` をそのまま返すガードを追加
- plain object のみ再帰変換するように制限（`isPlainObject` 追加）
- `Date` が保持されることを確認するテストを追加

## 確認
- `pnpm --filter @ojpp/api test` で成功

## 影響範囲
- `@ojpp/api` の `serializeBigInt` を利用するAPIレスポンス全般
