### PR TITLE
fix(api): ページングクエリを厳格にバリデーション

### DIFF
--- a/packages/api/src/__tests__/pagination.test.ts
+++ b/packages/api/src/__tests__/pagination.test.ts
@@ -1,6 +1,7 @@
+import type { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
-
-import { buildPaginatedResponse } from "../pagination";
+import { ApiError } from "../error";
+import { buildPaginatedResponse, parsePagination } from "../pagination";
 
 describe("buildPaginatedResponse", () => {
   it("正しいページネーション構造を返す", () => {
@@ -34,5 +35,35 @@ describe("buildPaginatedResponse", () => {
     expect(result.data).toEqual([]);
     expect(result.pagination.total).toBe(0);
     expect(result.pagination.totalPages).toBe(0);
+  });
+});
+
+describe("parsePagination", () => {
+  it("デフォルト値を返す", () => {
+    const request = { url: "https://example.com/api/items" } as NextRequest;
+    const result = parsePagination(request);
+    expect(result).toEqual({ page: 1, limit: 20, skip: 0 });
+  });
+
+  it("有効なページング値を返す", () => {
+    const request = {
+      url: "https://example.com/api/items?page=2&limit=10",
+    } as NextRequest;
+    const result = parsePagination(request);
+    expect(result).toEqual({ page: 2, limit: 10, skip: 10 });
+  });
+
+  it("小数は 400 エラー", () => {
+    const request = {
+      url: "https://example.com/api/items?page=1.5&limit=10",
+    } as NextRequest;
+    expect(() => parsePagination(request)).toThrowError(ApiError);
+  });
+
+  it("文字列は 400 エラー", () => {
+    const request = {
+      url: "https://example.com/api/items?page=abc&limit=10",
+    } as NextRequest;
+    expect(() => parsePagination(request)).toThrowError(ApiError);
   });
 });


### PR DESCRIPTION
## 概要
`parsePagination` が小数や文字列を許容してしまい、`skip/take` の不正値で実行時エラー（500）になる問題を修正します。

## 変更内容
- `page` / `limit` を正の整数のみ許可
- 不正値（小数・文字列・過大値）は `ApiError.badRequest` を投げて 400 として扱う
- `skip` の安全性（safe integer）も検証
- `parsePagination` の正常系/異常系テストを追加

## 確認
- `pnpm --filter @ojpp/api test` で成功

## 影響範囲
- `parsePagination` を利用する各 API ルート
