### PR TITLE
fix(api): Prisma入力バリデーションエラーを400に正規化

### DIFF
--- a/packages/api/src/__tests__/error.test.ts
+++ b/packages/api/src/__tests__/error.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { ApiError, handleApiError } from "../error";
+
+describe("handleApiError", () => {
+  it("ApiError をそのまま返す", async () => {
+    const response = handleApiError(ApiError.badRequest("invalid"));
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "invalid" });
+  });
+
+  it("Prisma のバリデーションエラーを 400 に変換する", async () => {
+    const response = handleApiError({
+      name: "PrismaClientValidationError",
+      message: "Invalid field value",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid request parameters" });
+  });
+
+  it("Prisma の known request validation code を 400 に変換する", async () => {
+    const response = handleApiError({
+      name: "PrismaClientKnownRequestError",
+      code: "P2009",
+    });
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ error: "Invalid request parameters" });
+  });
+});


### PR DESCRIPTION
## 概要
Prisma の入力バリデーション由来エラーが 500 で返るケースを、クライアント起因の 400 に正規化します。

## 変更内容
- `handleApiError` に Prisma バリデーションエラー判定を追加
  - `PrismaClientValidationError`
  - `PrismaClientKnownRequestError` の一部コード（`P2009` / `P2019` / `P2023`）
- 上記該当時は `400` + `Invalid request parameters` を返却
- `handleApiError` のテストを追加

## 確認
- `pnpm --filter @ojpp/api test` で成功

## 影響範囲
- `handleApiError` を利用する API エンドポイント全般
