### PR TITLE
fix(admin): Basic認証ミドルウェアの不正ヘッダ耐性を強化

### DIFF
--- a/apps/moneyglass-admin/src/middleware.ts
+++ b/apps/moneyglass-admin/src/middleware.ts
@@ -25,12 +25,20 @@ export function middleware(request: NextRequest) {
   if (authHeader) {
     const [scheme, encoded] = authHeader.split(" ");
     if (scheme === "Basic" && encoded) {
-      const decoded = atob(encoded);
-      const [user, pass] = decoded.split(":");
-      const expectedUser = process.env.ADMIN_USERNAME ?? "admin";
+      try {
+        const decoded = atob(encoded);
+        const separator = decoded.indexOf(":");
+        if (separator !== -1) {
+          const user = decoded.slice(0, separator);
+          const pass = decoded.slice(separator + 1);
+          const expectedUser = process.env.ADMIN_USERNAME ?? "admin";
 
-      if (safeEqual(user, expectedUser) && safeEqual(pass, password)) {
-        return NextResponse.next();
+          if (safeEqual(user, expectedUser) && safeEqual(pass, password)) {
+            return NextResponse.next();
+          }
+        }
+      } catch {
+        // 不正な Authorization ヘッダは認証失敗として扱う
       }
     }
   }

--- a/apps/parliscope-admin/src/middleware.ts
+++ b/apps/parliscope-admin/src/middleware.ts
@@ -25,12 +25,20 @@ export function middleware(request: NextRequest) {
   if (authHeader) {
     const [scheme, encoded] = authHeader.split(" ");
     if (scheme === "Basic" && encoded) {
-      const decoded = atob(encoded);
-      const [user, pass] = decoded.split(":");
-      const expectedUser = process.env.ADMIN_USERNAME ?? "admin";
+      try {
+        const decoded = atob(encoded);
+        const separator = decoded.indexOf(":");
+        if (separator !== -1) {
+          const user = decoded.slice(0, separator);
+          const pass = decoded.slice(separator + 1);
+          const expectedUser = process.env.ADMIN_USERNAME ?? "admin";
 
-      if (safeEqual(user, expectedUser) && safeEqual(pass, password)) {
-        return NextResponse.next();
+          if (safeEqual(user, expectedUser) && safeEqual(pass, password)) {
+            return NextResponse.next();
+          }
+        }
+      } catch {
+        // 不正な Authorization ヘッダは認証失敗として扱う
       }
     }
   }


### PR DESCRIPTION
## 概要
管理画面の Basic 認証ミドルウェアで、不正な `Authorization` ヘッダ（不正Base64など）により例外が発生し 500 になる可能性を修正します。

## 変更内容
- `atob` デコードを `try/catch` で保護
- `:` 区切りがないケースを明示的に拒否
- 不正ヘッダは例外を出さず、通常の認証失敗（401）として扱う
- `moneyglass-admin` / `parliscope-admin` の両ミドルウェアに同修正を適用

## 期待される効果
- 異常入力時の 500 を防止
- 認証の失敗系レスポンスを一貫化

## 影響範囲
- `/apps/moneyglass-admin` と `/apps/parliscope-admin` の管理画面認証
