### PR TITLE
fix(seatmap): APIエラーハンドリングを共通化して情報漏えいを防止

### DIFF
--- a/apps/seatmap-web/src/app/api/elections/[id]/route.ts
+++ b/apps/seatmap-web/src/app/api/elections/[id]/route.ts
@@ -1,18 +1,25 @@
-import { serializeBigInt } from "@ojpp/api";
+import { ApiError, handleApiError, jsonResponse, serializeBigInt } from "@ojpp/api";
 import { prisma } from "@ojpp/db";
-import { NextResponse } from "next/server";
 
 export async function GET(_req: Request, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params;
-  const election = await prisma.election.findUnique({
-    where: { id },
-    include: {
-      results: {
-        include: { party: true },
-        orderBy: { seatsWon: "desc" },
+  try {
+    const { id } = await params;
+    const election = await prisma.election.findUnique({
+      where: { id },
+      include: {
+        results: {
+          include: { party: true },
+          orderBy: { seatsWon: "desc" },
+        },
       },
-    },
-  });
-  if (!election) return NextResponse.json({ error: "Not found" }, { status: 404 });
-  return NextResponse.json(serializeBigInt(election));
+    });
+
+    if (!election) {
+      throw ApiError.notFound("Not found");
+    }
+
+    return jsonResponse(serializeBigInt(election));
+  } catch (error) {
+    return handleApiError(error);
+  }
 }

--- a/apps/seatmap-web/src/app/api/elections/route.ts
+++ b/apps/seatmap-web/src/app/api/elections/route.ts
@@ -1,6 +1,5 @@
-import { serializeBigInt } from "@ojpp/api";
+import { handleApiError, jsonResponse, serializeBigInt } from "@ojpp/api";
 import { prisma } from "@ojpp/db";
-import { NextResponse } from "next/server";
 
 export async function GET() {
   try {
@@ -13,9 +12,8 @@ export async function GET() {
       },
       orderBy: { date: "desc" },
     });
-    return NextResponse.json(serializeBigInt(elections));
+    return jsonResponse(serializeBigInt(elections));
   } catch (error) {
-    console.error("[SeatMap API] Election query failed:", error);
-    return NextResponse.json({ error: String(error) }, { status: 500 });
+    return handleApiError(error);
   }
 }


### PR DESCRIPTION
## 概要
SeatMap の API が内部エラーを `String(error)` でそのまま返していたため、情報漏えいリスクがある状態を修正します。

## 変更内容
- `apps/seatmap-web/src/app/api/elections/route.ts`
  - `NextResponse.json` 直返しをやめ、`@ojpp/api` の `handleApiError` / `jsonResponse` に統一
- `apps/seatmap-web/src/app/api/elections/[id]/route.ts`
  - 404 を `ApiError.notFound` で統一
  - 例外時は `handleApiError` で安全にレスポンス化

## 期待される効果
- 内部エラー詳細の外部露出を防止
- SeatMap API のエラーレスポンス形式を他サービスと揃える

## 影響範囲
- SeatMap の `elections` API (`/api/elections`, `/api/elections/[id]`)
