### PR TITLE
chore: use workspace catalog for next in broadlistening-web

### DIFF
--- a/apps/broadlistening-web/package.json
+++ b/apps/broadlistening-web/package.json
@@ -15,7 +15,7 @@
     "@ojpp/db": "workspace:*",
     "@ojpp/ui": "workspace:*",
     "@anthropic-ai/sdk": "^0.39.0",
-    "next": "^15.2.0",
+    "next": "catalog:",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ catalogs:
       specifier: ^11.0.0
       version: 11.0.0
     next:
-      specifier: ^15.2.0
+      specifier: ^15.5.12
       version: 15.5.12
     react:
       specifier: ^19.0.0
@@ -72,7 +72,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/ui
       next:
-        specifier: ^15.2.0
+        specifier: 'catalog:'
         version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ onlyBuiltDependencies:
   - prisma
   - esbuild
 catalog:
-  next: ^15.2.0
+  next: ^15.5.12
   react: ^19.0.0
   react-dom: ^19.0.0
   "@types/react": ^19.0.0


### PR DESCRIPTION
## 変更内容

- broadlistening-web だけ `"next": "^15.2.0"` となっており、他のアプリと同じく `catalog:` を使用し、一貫性をもたせる。
- `pnpm-workspace.yaml` でも `"next": "^15.2.0"` となっており昨年末の脆弱性バージョンを排除しない形になっているので、lockfileですでに指定している `^15.5.12` まで bump up.

脆弱性参照
https://nextjs.org/blog/CVE-2025-66478


## 関連 Issue

no issue

## 変更の種類

<!-- 該当するものにチェック -->
- [ ] バグ修正
- [ ] 新機能
- [ ] ドキュメント更新
- [ ] リファクタリング
- [ ] データ追加・修正
- [ ] CI/CD・インフラ
- [ ] テスト追加・修正
---
- [x] package management chore

## チェックリスト

- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る
- [x] `pnpm test` が通る
- [ ] `pnpm build` が通る (`setup.sh` の精査できてないので、行っていません)
- [x] 非党派性を保っている（特定政党に有利/不利な変更を含まない）
- [x] 個人情報を含まない
