### PR TITLE
test: security.ts と rate-limit.ts のユニットテスト追加

### DIFF
--- a/packages/api/src/__tests__/rate-limit.test.ts
+++ b/packages/api/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,41 @@
+import type { NextRequest } from "next/server";
+import { describe, expect, it } from "vitest";
+
+import { checkRateLimit } from "../rate-limit";
+
+function createRequest(ip: string): NextRequest {
+  return {
+    headers: new Headers({ "x-forwarded-for": ip }),
+  } as unknown as NextRequest;
+}
+
+describe("checkRateLimit", () => {
+  it("制限内のリクエストで null を返す", () => {
+    const request = createRequest("10.0.0.1");
+    const result = checkRateLimit(request, { limit: 10, windowMs: 60_000 });
+    expect(result).toBeNull();
+  });
+
+  it("制限を超えたリクエストで 429 レスポンスを返す", () => {
+    const request = createRequest("10.0.0.2");
+    const config = { limit: 2, windowMs: 60_000 };
+
+    checkRateLimit(request, config); // 1
+    checkRateLimit(request, config); // 2
+    const result = checkRateLimit(request, config); // 3 → 超過
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe(429);
+  });
+
+  it("429 レスポンスに Retry-After ヘッダーが含まれる", () => {
+    const request = createRequest("10.0.0.3");
+    const config = { limit: 1, windowMs: 60_000 };
+
+    checkRateLimit(request, config); // 1
+    const result = checkRateLimit(request, config); // 2 → 超過
+
+    expect(result).not.toBeNull();
+    expect(result!.headers.get("Retry-After")).toBeTruthy();
+  });
+});

--- a/packages/api/src/__tests__/security.test.ts
+++ b/packages/api/src/__tests__/security.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+
+import { safeEqual } from "../security";
+
+describe("safeEqual", () => {
+  it("同じ文字列で true を返す", () => {
+    expect(safeEqual("hello", "hello")).toBe(true);
+  });
+
+  it("異なる文字列で false を返す", () => {
+    expect(safeEqual("hello", "world")).toBe(false);
+  });
+
+  it("空文字列同士で true を返す", () => {
+    expect(safeEqual("", "")).toBe(true);
+  });
+
+  it("長さが異なる文字列で false を返す", () => {
+    expect(safeEqual("short", "much longer string")).toBe(false);
+  });
+});


### PR DESCRIPTION
## 変更内容

`packages/api/src/` の `security.ts`（`safeEqual`）と `rate-limit.ts`（`checkRateLimit`）にユニットテストがなかったため追加しました。既存テスト（`pagination.test.ts`, `error.test.ts`, `serialize.test.ts`）のスタイルに準拠しています。

### 追加テスト

**`security.test.ts`** — `safeEqual` 関数:
- 同じ文字列で `true` を返す
- 異なる文字列で `false` を返す
- 空文字列同士の比較
- 長さが異なる文字列で `false` を返す

**`rate-limit.test.ts`** — `checkRateLimit` 関数:
- 制限内のリクエストで `null` を返す
- 制限超過で `429` レスポンスを返す
- `Retry-After` ヘッダーが含まれることを確認

## 関連 Issue

セキュリティ関連モジュール（#18〜#22 で修正済み）のテストカバレッジ向上

## 変更の種類

- [x] テスト追加・修正

## チェックリスト

- [x] `pnpm lint` が通る
- [x] `pnpm typecheck` が通る
- [x] `pnpm test` が通る（全25テストパス）
- [x] `pnpm build` が通る
- [x] 非党派性を保っている（特定政党に有利/不利な変更を含まない）
- [x] 個人情報を含まない

---

<!-- AIエージェント（Claude Code）による PR -->
**エージェント行動ログ**: `entire explain --checkpoint c4a69b25bc74` でセッションの推論プロセスを確認できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code) + [Entire](https://entire.io/)